### PR TITLE
fix: Correct alpine-base example path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,8 +221,7 @@ jobs:
     - name: Test multi-platform build with Alpine base
       run: |
         # Test that platform detection works (even if we can't build all platforms)
-        cd example/alpine-base
-        ../target/release/krust build --no-push --image test.local/alpine-test:latest . 2>&1 | tee build.log
+        ./target/release/krust build --no-push --image test.local/alpine-test:latest ./example/alpine-base 2>&1 | tee build.log
 
         # Verify platform detection happened
         grep -q "Detecting available platforms from base image: alpine:latest" build.log


### PR DESCRIPTION
## Summary
Fixes the CI failure in the extended-platforms job by correcting how the alpine-base example is invoked.

## Problem
The CI was failing with:
```
cd example/alpine-base
../target/release/krust build --no-push --image test.local/alpine-test:latest . 2>&1 | tee build.log
```

This fails because:
1. When we `cd` into the example directory, the relative path to the krust binary becomes incorrect
2. The build.log file would be created in the wrong directory

## Solution
Use the correct approach by passing the path directly to krust:
```
./target/release/krust build --no-push --image test.local/alpine-test:latest ./example/alpine-base 2>&1 | tee build.log
```

This ensures:
- The krust binary is found correctly
- The build.log is created in the workflow's working directory
- The alpine-base example is properly referenced

## Test Plan
- [x] CI should pass after this fix
- [x] The extended-platforms job should successfully test Alpine platform detection

🤖 Generated with [Claude Code](https://claude.ai/code)