### PR TITLE
Update documentation and mark multi-platform support as complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ Convenience wrapper that combines `resolve` with `kubectl apply`:
 Potential enhancements identified:
 1. ~~Registry authentication support~~ ✓ Implemented (supports Docker credential helpers)
 2. ~~YAML resolution for Kubernetes deployments~~ ✓ Implemented (`krust resolve`)
-3. Multi-platform image manifests
+3. ~~Multi-platform image manifests~~ ✓ Implemented (OCI image index with concurrent builds)
 4. ~~Build caching~~ ✓ Implemented (persistent `target/krust/` directory)
 5. Image layer optimization
 6. Support for custom Dockerfile-like configs

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ krust builds your Rust application and packages it into a container image:
 krust builds fully static binaries by default using:
 - musl libc for Linux targets
 - `RUSTFLAGS="-C target-feature=+crt-static"` for static linking
-- Distroless static base image (`gcr.io/distroless/static:nonroot`)
+- Distroless static base image (`cgr.dev/chainguard/static:latest`)
 
 This ensures your applications work across all Linux distributions without dependency issues.
 
@@ -289,13 +289,14 @@ Arguments:
   [CARGO_ARGS]...  Additional cargo build arguments
 
 Options:
-  -i, --image <IMAGE>        Target image reference (overrides KRUST_REPO)
-      --platform <PLATFORM>  Target platform [default: linux/amd64]
+      --platform <PLATFORM>  Target platforms (comma-separated, auto-detected from base image if not specified)
       --no-push              Skip pushing the image to registry
       --tag <TAG>            Tag to apply to the image (e.g., latest, v1.0.0)
-      --repo <REPO>          Repository prefix (uses KRUST_REPO env var)
-  -v, --verbose              Enable verbose logging
+      --repo <REPO>          Repository prefix (defaults to KRUST_REPO env var)
   -h, --help                 Print help
+
+Global Options:
+  -v, --verbose              Enable verbose logging
 ```
 
 ### Resolve Command
@@ -310,10 +311,12 @@ Arguments:
 
 Options:
       --platform <PLATFORM>  Target platforms (comma-separated)
-      --repo <REPO>          Repository prefix (uses KRUST_REPO env var)
+      --repo <REPO>          Repository prefix (defaults to KRUST_REPO env var)
       --tag <TAG>            Tag to apply to built images
-  -v, --verbose              Enable verbose logging
   -h, --help                 Print help
+
+Global Options:
+  -v, --verbose              Enable verbose logging
 ```
 
 #### Usage Examples
@@ -374,10 +377,12 @@ Arguments:
 
 Options:
       --platform <PLATFORM>  Target platforms (comma-separated)
-      --repo <REPO>          Repository prefix (uses KRUST_REPO env var)
+      --repo <REPO>          Repository prefix (defaults to KRUST_REPO env var)
       --tag <TAG>            Tag to apply to built images
-  -v, --verbose              Enable verbose logging
   -h, --help                 Print help
+
+Global Options:
+  -v, --verbose              Enable verbose logging
 ```
 
 #### Usage Examples
@@ -398,6 +403,14 @@ The `apply` command is equivalent to:
 ```bash
 krust resolve -f deployment.yaml | kubectl apply -f -
 ```
+
+### Version Command
+
+```
+krust version
+```
+
+Prints the current krust version.
 
 ## Troubleshooting
 
@@ -488,7 +501,7 @@ make test-e2e          # End-to-end tests only
 cargo test -- --test-threads=1
 
 # Run with verbose output
-make test-verbose
+cargo test --verbose -- --test-threads=1
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A container image build tool for Rust applications, inspired by [`ko`](https://k
 ## Overview
 
 krust builds container images for Rust applications without requiring Docker. It:
-- Executes `cargo build` to compile your Rust application as a static binary using musl libc
+- Uses [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild) to compile your Rust application as a static binary using musl libc
 - Packages the resulting binary into a minimal container image layer
 - Pushes images to OCI-compliant registries by default (use `--no-push` to skip)
 - Creates truly static binaries by default for maximum portability and security
@@ -15,6 +15,10 @@ krust builds container images for Rust applications without requiring Docker. It
 ## Quick Start
 
 ```bash
+# Install prerequisites
+cargo install cargo-zigbuild
+# Also install zig: brew install zig (macOS) or see https://ziglang.org/download/
+
 # Install krust
 cargo install --path .
 
@@ -33,7 +37,7 @@ cargo install --path .
 
 ### Prerequisites
 
-Install [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild) for cross-compilation (recommended):
+krust requires [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation:
 
 ```bash
 # Install zig (cargo-zigbuild's cross-compilation backend)
@@ -46,7 +50,7 @@ sudo snap install zig --classic --beta  # or via your package manager
 cargo install cargo-zigbuild
 ```
 
-krust will automatically install the required rustup targets when building. If `cargo-zigbuild` is not installed, krust falls back to `cargo build` and will attempt to find a system cross-linker.
+krust will automatically install the required rustup targets when building, but `cargo-zigbuild` and `zig` must be installed beforehand.
 
 Note: krust builds fully static binaries by default using musl libc, ensuring maximum portability across different Linux distributions and container environments.
 
@@ -138,7 +142,7 @@ krust builds your Rust application and packages it into a container image:
 
 1. **Target installation** - Automatically installs the required rustup target if missing
 2. **Static compilation** - Builds with `RUSTFLAGS="-C target-feature=+crt-static"` for musl targets
-3. **Cross-compilation** - Uses `cargo-zigbuild` for seamless cross-compilation (falls back to `cargo build` with system linkers)
+3. **Cross-compilation** - Uses `cargo-zigbuild` for seamless cross-compilation to any supported platform
 4. **Cached builds** - Uses `target/krust/` as the build directory, so incremental compilation works across runs
 5. **Container creation** - Packages the binary into a minimal OCI image
 
@@ -416,12 +420,12 @@ Prints the current krust version.
 
 ### "linking with `cc` failed" or linker errors
 
-Install `cargo-zigbuild` for seamless cross-compilation:
+Ensure `cargo-zigbuild` and `zig` are installed:
 ```bash
 cargo install cargo-zigbuild
+# macOS: brew install zig
+# Linux: sudo snap install zig --classic --beta
 ```
-
-If you prefer not to use zigbuild, install the appropriate system cross-linker for your target platform.
 
 ### Platform mismatch warning when running images
 


### PR DESCRIPTION
## Summary
This PR updates the README and CLAUDE.md documentation to reflect recent changes and improvements to the krust project, including updated base image references, reorganized CLI help text, and completion of multi-platform image manifest support.

## Key Changes

- **Base Image Update**: Changed default distroless base image from `gcr.io/distroless/static:nonroot` to `cgr.dev/chainguard/static:latest` for improved security and maintenance
- **CLI Documentation Reorganization**: 
  - Moved `--verbose` flag to a new "Global Options" section in build, resolve, and apply command documentation
  - Updated `--platform` flag description to clarify comma-separated format and auto-detection from base image
  - Improved wording for `--repo` option description (changed "uses" to "defaults to")
  - Removed `-i, --image` option from build command documentation
- **New Version Command**: Added documentation for the `version` command that prints the current krust version
- **Feature Completion**: Marked multi-platform image manifests as implemented in CLAUDE.md (OCI image index with concurrent builds)
- **Test Documentation**: Updated test command example to use `cargo test --verbose` directly instead of `make test-verbose`

## Notable Details

The changes primarily focus on documentation accuracy and clarity, reflecting the current state of the CLI interface and completed features. The base image update to Chainguard's static image represents a shift toward more actively maintained and security-focused container images.

https://claude.ai/code/session_019QkKmgPcFYaLwKe34EMFJy